### PR TITLE
Invalid syntax in index.py in _error_messages #2086

### DIFF
--- a/index.py
+++ b/index.py
@@ -182,7 +182,7 @@ class DocumentType(ModelSQL, ModelView):
             ('check_mapping', 'wrong_mapping'),
         ]
         cls._error_messages.update({
-            ('wrong_mapping', 'Mapping does not seem to be valid JSON'),
+            'wrong_mapping': 'Mapping does not seem to be valid JSON',
         })
 
     def check_mapping(self):


### PR DESCRIPTION
- This patch includes a fix in index.py, as _error_messages takes a
  dictionary
