### PR TITLE
Properties must be part of mapping

### DIFF
--- a/index.py
+++ b/index.py
@@ -317,8 +317,6 @@ class DocumentType(ModelSQL, ModelView):
         for document_type in document_types:
             conn.indices.put_mapping(
                 config.make_type_name(document_type.model.model),   # Type
-                {
-                    'properties': json.loads(document_type.mapping),
-                },
+                json.loads(document_type.mapping),                  # Mapping
                 [config.index_name],                                # Index
             )


### PR DESCRIPTION
This approach is more flexible as other attributes
in addition to properties could be specified by
models.
